### PR TITLE
Added header comp and fixed auth routing

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,6 +1,7 @@
-import { Route, Routes } from "react-router-dom";
+import { Navigate, Route, Routes } from "react-router-dom";
 import UserAuthPage from "./components/UserAuthPage";
 import HomePage from "./components/Home/HomePage";
+import useUserStore from "./lib/usercontext";
 
 interface AuthPageWrapperProps {
   isSignup: boolean;
@@ -19,6 +20,12 @@ function App() {
 }
 
 function AuthPageWrapper({ isSignup }: AuthPageWrapperProps) {
+  const { user } = useUserStore();
+
+  if (user) {
+    return <Navigate to="/" replace />;
+  }
+
   return <UserAuthPage signup={isSignup} />;
 }
 

--- a/client/src/actions/getUser.tsx
+++ b/client/src/actions/getUser.tsx
@@ -12,6 +12,6 @@ async function fetchUser() {
 
 export default function getUser() {
   return useQuery(["user"], fetchUser, {
-    retry: 2,
+    retry: 1,
   });
 }

--- a/client/src/components/Home/HomePage.tsx
+++ b/client/src/components/Home/HomePage.tsx
@@ -1,10 +1,12 @@
 import React from "react";
 import Navbar from "./_components/Navbar";
+import Header from "./_components/Header";
 
 export default function HomePage() {
   return (
     <div className="bg-background">
       <Navbar />
+      <Header />
     </div>
   );
 }

--- a/client/src/components/Home/_components/Header.tsx
+++ b/client/src/components/Home/_components/Header.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+export default function Header() {
+  return (
+    <section className="flex flex-col items-center justify-center h-[25rem]">
+      <h1 className="px-1 text-4xl font-extrabold tracking-wider scroll-m-20 lg:text-5xl text-primary ">
+        Easy Boards
+      </h1>
+      <p className="leading-7 [&:not(:first-child)]:mt-6 text-muted-foreground max-w-xl text-center">
+        Embrace clarity and momentum with EasyBoards – because when it comes to
+        managing work, simplicity and functionality should go hand in hand.
+      </p>
+    </section>
+  );
+}

--- a/client/src/components/Home/_components/HoverComponents.tsx
+++ b/client/src/components/Home/_components/HoverComponents.tsx
@@ -10,6 +10,7 @@ import {
   navigationMenuTriggerStyle,
 } from "@/components/ui/navigation-menu";
 import { useTheme } from "@/providers/theme-provider";
+import useUserStore from "@/lib/usercontext";
 
 const components: { title: string; href: string; description: string }[] = [
   {
@@ -50,6 +51,7 @@ const components: { title: string; href: string; description: string }[] = [
 ];
 export default function HoverComponents() {
   const { theme } = useTheme();
+  const { user } = useUserStore();
   return (
     <NavigationMenu>
       <NavigationMenuList>
@@ -117,8 +119,11 @@ export default function HoverComponents() {
             "bg-background": theme === "dark",
           })}
         >
-          <a href="/docs" className={navigationMenuTriggerStyle()}>
-            <NavigationMenuLink>Documentation</NavigationMenuLink>
+          <a
+            href={`/users/${user?.id}/dashboard`}
+            className={navigationMenuTriggerStyle()}
+          >
+            <NavigationMenuLink>Dashboard</NavigationMenuLink>
           </a>
         </NavigationMenuItem>
       </NavigationMenuList>

--- a/client/src/components/Home/_components/Navbar.tsx
+++ b/client/src/components/Home/_components/Navbar.tsx
@@ -13,7 +13,7 @@ import { Spinner } from "@/lib/spinner";
 export default function Navbar() {
   const { theme } = useTheme();
   const { user, setUser } = useUserStore();
-  const { data, isLoading, isError } = getUser();
+  const { data, isLoading } = getUser();
   const navigate = useNavigate();
   useEffect(() => {
     if (data) {


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> # TL;DR
> This pull request introduces several changes to the client-side of the application. It includes the addition of a new `Header` component to the `HomePage`, a reduction in the retry attempts for the `getUser` action, and a redirection to the home page if a user is already authenticated. It also includes a change in the navigation menu link from "Documentation" to "Dashboard".
> 
> # What changed
> 1. **User Authentication**: The `AuthPageWrapper` now checks if a user is already authenticated. If so, it redirects them to the home page.
> 2. **Retry Attempts**: The `getUser` action now only retries once if it fails initially.
> 3. **New Header Component**: A new `Header` component has been added to the `HomePage` component.
> 4. **Navigation Menu Link**: The navigation menu link has been changed from "Documentation" to "Dashboard".
> 
> # How to test
> 1. **User Authentication**: Try to access the authentication page while already logged in. You should be redirected to the home page.
> 2. **Retry Attempts**: Introduce an error in the `getUser` action and observe that it only retries once.
> 3. **New Header Component**: Visit the home page and observe the new `Header` component.
> 4. **Navigation Menu Link**: Click on the navigation menu link and observe that it now redirects to the "Dashboard" instead of "Documentation".
> 
> # Why make this change
> 1. **User Authentication**: This change improves user experience by preventing already authenticated users from accessing the authentication page.
> 2. **Retry Attempts**: Reducing the retry attempts can help prevent unnecessary API calls and potential rate limiting issues.
> 3. **New Header Component**: The new `Header` component enhances the visual appeal of the home page.
> 4. **Navigation Menu Link**: Changing the navigation menu link to "Dashboard" makes it more relevant to the user's needs.
</details>